### PR TITLE
Fix back/finger runes

### DIFF
--- a/SetsUI.lua
+++ b/SetsUI.lua
@@ -199,9 +199,11 @@ local function Setup()
     if button == "RightButton" then
       local castInfo = C_Engraving.GetCurrentRuneCast()
       if castInfo and castInfo.equipmentSlot then
+        slot = castInfo.equipmentSlot
+        if slot == INVSLOT_MAINHAND then slot = INVSLOT_BACK end
         addon._isEngraving = true
         addon.utils.Suppress(addon._isEngraving)
-        UseInventoryItem(castInfo.equipmentSlot, "player")
+        UseInventoryItem(slot, "player")
         local dialog = StaticPopup_FindVisible("REPLACE_ENCHANT")
         if dialog then
           _G[dialog:GetName().."Button1"]:Click()
@@ -822,9 +824,11 @@ function addon.RunSet(set_id)
         C_Engraving.CastRune(skillLineAbilityID)
         local castInfo = C_Engraving.GetCurrentRuneCast()
         if castInfo and castInfo.equipmentSlot then
+          slot = castInfo.equipmentSlot
+          if slot == INVSLOT_MAINHAND then slot = INVSLOT_BACK end
           addon._isEngraving = true
           addon.utils.Suppress(addon._isEngraving)
-          UseInventoryItem(castInfo.equipmentSlot, "player")
+          UseInventoryItem(slot, "player")
           local dialog = StaticPopup_FindVisible("REPLACE_ENCHANT")
           if dialog then
             _G[dialog:GetName().."Button1"]:Click()
@@ -909,6 +913,8 @@ function addon.SetButton.PreClick(self, button)
   if castInfo and castInfo.equipmentSlot then
     local setID = self:GetID()
     local slot = castInfo.equipmentSlot
+    if slot == INVSLOT_MAINHAND then slot = INVSLOT_BACK end
+    if slot == INVSLOT_FINGER1 and button == "RightButton" then slot = INVSLOT_FINGER2 end
     local skillLineAbilityID = castInfo.skillLineAbilityID
     local name = castInfo.name
     local icon = castInfo.iconTexture
@@ -934,9 +940,11 @@ function addon.SetButton.PostClick(self, button)
         C_Engraving.CastRune(skillLineAbilityID)
         local castInfo = C_Engraving.GetCurrentRuneCast()
         if castInfo and castInfo.equipmentSlot then
+          slot = castInfo.equipmentSlot
+          if slot == INVSLOT_MAINHAND then slot = INVSLOT_BACK end
           addon._isEngraving = true
           addon.utils.Suppress(addon._isEngraving)
-          UseInventoryItem(castInfo.equipmentSlot, "player")
+          UseInventoryItem(slot, "player")
           local dialog = StaticPopup_FindVisible("REPLACE_ENCHANT")
           if dialog then
             _G[dialog:GetName().."Button1"]:Click()


### PR DESCRIPTION
There are 2 issues currently with the handling of back and finger runes in the addon:

1. Some back runes are incorrectly reported as a main hand weapon slot by the WoW API in the castInfo, so they cannot be applied. This should be the same issue as reported in #5 
2. Finger runes can only be applied to the FINGER1 slot.

I fixed 1. by adding a few check that replace the inventory slot with the back slot when the main hand gets reported. This is a temporary fix, which should be removed when blizzard fixes the API, and it will break things when main hand runes get added. Right now, there are no main hand runes in the game, so it's safe.

I fixed 2. by allowing the use of a right click when adding a rune to a set, to designate that this rune should be applied to the seconds finger slot. Easy and fast fix. Right clicking on a rune will still only be able to apply it to the first finger slot, but at least you can add it to the sets correctly, and you can always just use the left click and select the slot yourself when manually applying finger runes.
